### PR TITLE
fix: Исправлена ошибка установки модели восстановления.

### DIFF
--- a/src/core/Классы/ПодключениеMSSQL.os
+++ b/src/core/Классы/ПодключениеMSSQL.os
@@ -650,7 +650,7 @@
 
 	ТекстЗапроса = СтрШаблон("""USE [master];
 	                         |
-	                         |ALTER DATABASE %1
+	                         |ALTER DATABASE [%1]
 	                         |SET RECOVERY %2"" ",
 	                         База,
 	                         МодельВосстановления);


### PR DESCRIPTION
КРИТИЧНАЯОШИБКА - [oscript.app.cpdb] - {Модуль D:\programs\OneScript\lib\cpdb\src\core\Классы\РаботаССУБД.os / Ошибка в строке: 400 / Ошибка смены модели восстановления базы "ERP-UH_build" на "SIMPLE":
{Модуль D:\programs\OneScript\lib\cpdb\src\core\Классы\ПодключениеMSSQL.os / Ошибка в строке: 637 / Ошибка получения модели восстановления базы "ERP-UH_build":
Msg 102, Level 15, State 1, Server 1C-SQL-TEST, Line 3
Incorrect syntax near '-'.}